### PR TITLE
feat(cb2-15350): added abandoned certs feature flag

### DIFF
--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-feature-flags",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Common package to be used in CVS to manage feature flags",
   "author": "DVSA",
   "license": "ISC",

--- a/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
+++ b/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
@@ -41,7 +41,7 @@ describe('app config configuration', () => {
 			},
 			abandonedCerts: {
 				enabled: true,
-			}
+			},
 		};
 
 		getAppConfig.mockReturnValue(expectedFlags);

--- a/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
+++ b/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
@@ -14,11 +14,14 @@ describe('app config configuration', () => {
 
 		const flags = await getProfile();
 
-		expect(flags.welshTranslation.enabled).toBe(false);
-		expect(flags.welshTranslation.translatePassTestResult).toBe(false);
+		expect(flags.welshTranslation.enabled).toBe(true);
+		expect(flags.welshTranslation.translatePassTestResult).toBe(true);
+		expect(flags.welshTranslation.translateFailTestResult).toBe(true);
+		expect(flags.welshTranslation.translatePrsTestResult).toBe(true);
 		expect(flags.issueDocsCentrally.enabled).toBe(true);
 		expect(flags.recallsApi.enabled).toBe(false);
 		expect(flags.automatedCt.enabled).toBe(false);
+		expect(flags.abandonedCerts.enabled).toBe(false);
 	});
 
 	it('should override some flags with a partial response', async () => {
@@ -36,6 +39,9 @@ describe('app config configuration', () => {
 			automatedCt: {
 				enabled: true,
 			},
+			abandonedCerts: {
+				enabled: true,
+			}
 		};
 
 		getAppConfig.mockReturnValue(expectedFlags);
@@ -44,9 +50,11 @@ describe('app config configuration', () => {
 
 		expect(flags.welshTranslation.enabled).toBe(true);
 		expect(flags.welshTranslation.translatePassTestResult).toBe(true);
-		expect(flags.welshTranslation.translateFailTestResult).toBe(false);
+		expect(flags.welshTranslation.translateFailTestResult).toBe(true);
+		expect(flags.welshTranslation.translatePrsTestResult).toBe(true);
 		expect(flags.issueDocsCentrally.enabled).toBe(false);
 		expect(flags.recallsApi.enabled).toBe(true);
 		expect(flags.automatedCt.enabled).toBe(true);
+		expect(flags.abandonedCerts.enabled).toBe(true);
 	});
 });

--- a/packages/feature-flags/src/profiles/vtx.ts
+++ b/packages/feature-flags/src/profiles/vtx.ts
@@ -4,10 +4,10 @@ import { getFeatureFlags } from '../feature-flags';
 
 const defaultFeatureFlags = {
 	welshTranslation: {
-		enabled: false,
-		translatePassTestResult: false,
-		translateFailTestResult: false,
-		translatePrsTestResult: false,
+		enabled: true,
+		translatePassTestResult: true,
+		translateFailTestResult: true,
+		translatePrsTestResult: true,
 	},
 	issueDocsCentrally: {
 		enabled: true,
@@ -18,6 +18,9 @@ const defaultFeatureFlags = {
 	automatedCt: {
 		enabled: false,
 	},
+	abandonedCerts: {
+		enabled: false,
+	}
 };
 
 export type FeatureFlags = typeof defaultFeatureFlags;

--- a/packages/feature-flags/src/profiles/vtx.ts
+++ b/packages/feature-flags/src/profiles/vtx.ts
@@ -20,7 +20,7 @@ const defaultFeatureFlags = {
 	},
 	abandonedCerts: {
 		enabled: false,
-	}
+	},
 };
 
 export type FeatureFlags = typeof defaultFeatureFlags;


### PR DESCRIPTION
## VTx - VTG/VTP12 can be generated from abandoned test's

This code adds new feature flag for the generation of abandoned certificates - VTG12 and VTP12.

Also updated the default values for the welshTranslation feature flags to true as all of those features have now been released and are enabled in production.

Related issue: [CB2-15350](https://dvsa.atlassian.net/browse/CB2-15350)

## Before submitting (or marking as "ready for review")

- [X] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [X] Have you have added tests that prove the fix or feature is effective and working
- [X] Did you make sure to update any documentation relating to this change?
