### PR TITLE
feat(cb2-16077): Update Default Values for Flags

### DIFF
--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-feature-flags",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Common package to be used in CVS to manage feature flags",
   "author": "DVSA",
   "license": "ISC",

--- a/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
+++ b/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
@@ -19,9 +19,9 @@ describe('app config configuration', () => {
 		expect(flags.welshTranslation.translateFailTestResult).toBe(true);
 		expect(flags.welshTranslation.translatePrsTestResult).toBe(true);
 		expect(flags.issueDocsCentrally.enabled).toBe(true);
-		expect(flags.recallsApi.enabled).toBe(false);
+		expect(flags.recallsApi.enabled).toBe(true);
 		expect(flags.automatedCt.enabled).toBe(false);
-		expect(flags.abandonedCerts.enabled).toBe(false);
+		expect(flags.abandonedCerts.enabled).toBe(true);
 	});
 
 	it('should override some flags with a partial response', async () => {

--- a/packages/feature-flags/src/profiles/vtx.ts
+++ b/packages/feature-flags/src/profiles/vtx.ts
@@ -13,13 +13,13 @@ const defaultFeatureFlags = {
 		enabled: true,
 	},
 	recallsApi: {
-		enabled: false,
+		enabled: true,
 	},
 	automatedCt: {
 		enabled: false,
 	},
 	abandonedCerts: {
-		enabled: false,
+		enabled: true,
 	},
 };
 


### PR DESCRIPTION
## Description

Following the release of BE 5.29, a number of new flags will then be ON by default.

- updated default flag values to true for recalls and abandonedCerts
- updated unit tests for above

Related issue: [CB2-16077](https://dvsa.atlassian.net/browse/CB2-16077)

## Before submitting (or marking as "ready for review")

- [X] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [X] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
