### PR TITLE
feat: add adas defect feature flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20148,7 +20148,7 @@
     },
     "packages/feature-flags": {
       "name": "@dvsa/cvs-feature-flags",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "ISC",
       "dependencies": {
         "@aws-lambda-powertools/parameters": "^2.16.0",

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-feature-flags",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Common package to be used in CVS to manage feature flags",
   "author": "DVSA",
   "license": "ISC",

--- a/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
+++ b/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
@@ -45,7 +45,7 @@ describe('app config configuration', () => {
 				enabled: true,
 			},
 			specialistDefects: {
-				enableIM29: true,
+				enabled: true,
 				adasImNumbers: [29, 99],
 			},
 		};
@@ -62,6 +62,7 @@ describe('app config configuration', () => {
 		expect(flags.recallsApi.enabled).toBe(true);
 		expect(flags.automatedCt.enabled).toBe(true);
 		expect(flags.abandonedCerts.enabled).toBe(true);
+		expect(flags.specialistDefects.enabled).toBe(true);
 		expect(flags.specialistDefects.adasImNumbers).toEqual([29, 99]);
 	});
 });

--- a/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
+++ b/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
@@ -22,6 +22,8 @@ describe('app config configuration', () => {
 		expect(flags.recallsApi.enabled).toBe(true);
 		expect(flags.automatedCt.enabled).toBe(false);
 		expect(flags.abandonedCerts.enabled).toBe(true);
+		expect(flags.specialistDefects.enabled).toBe(false);
+		expect(flags.specialistDefects.adasImNumbers).toEqual([29]);
 	});
 
 	it('should override some flags with a partial response', async () => {
@@ -42,6 +44,10 @@ describe('app config configuration', () => {
 			abandonedCerts: {
 				enabled: true,
 			},
+			specialistDefects: {
+				enableIM29: true,
+				adasImNumbers: [29, 99],
+			},
 		};
 
 		getAppConfig.mockReturnValue(expectedFlags);
@@ -56,5 +62,6 @@ describe('app config configuration', () => {
 		expect(flags.recallsApi.enabled).toBe(true);
 		expect(flags.automatedCt.enabled).toBe(true);
 		expect(flags.abandonedCerts.enabled).toBe(true);
+		expect(flags.specialistDefects.adasImNumbers).toEqual([29, 99]);
 	});
 });

--- a/packages/feature-flags/src/profiles/vtx.ts
+++ b/packages/feature-flags/src/profiles/vtx.ts
@@ -21,6 +21,10 @@ const defaultFeatureFlags = {
 	abandonedCerts: {
 		enabled: true,
 	},
+	specialistDefects: {
+		enabled: false,
+		adasImNumbers: [29],
+	},
 
 	/**
 	 * Feature flags for the CVS test facility domain


### PR DESCRIPTION
## Description

Add ADAS defect feature flags to enable VTx to return / not return ADAS advisory defects in the defect endpoint payload.

Related issue: [CB2-18600](https://dvsa.atlassian.net/browse/CB2-18600)

## Before submitting (or marking as "ready for review")

- [X] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [X] Have you have added tests that prove the fix or feature is effective and working
- [X] Did you make sure to update any documentation relating to this change?


[CB2-18600]: https://dvsa.atlassian.net/browse/CB2-18600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ