### PR TITLE
feat(service-bundler): scan functions for routing controllers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20994,7 +20994,7 @@
     },
     "packages/service-bundler": {
       "name": "@dvsa/service-bundler",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
         "@rspack/core": "1.7.4",

--- a/packages/service-bundler/package.json
+++ b/packages/service-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/service-bundler",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "DVSA",
   "license": "ISC",
   "repository": {

--- a/packages/service-bundler/src/index.ts
+++ b/packages/service-bundler/src/index.ts
@@ -1,5 +1,5 @@
 import { type Dirent, existsSync, readdirSync } from 'node:fs';
-import { stat } from 'node:fs/promises';
+import { readFile, readdir, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { DefinePlugin, type RspackOptions, Stats, rspack } from '@rspack/core';
 import { copy } from 'fs-extra';
@@ -260,6 +260,40 @@ export class ServicePackager {
 		});
 	}
 
+	private static async assertArtifactDoesNotReferencePackage(
+		artifactDir: string,
+		packageName: string,
+		context: string
+	) {
+		const files = await ServicePackager.getFiles(artifactDir);
+
+		for (const file of files) {
+			if (!/\.[cm]?js$/.test(file)) {
+				continue;
+			}
+
+			const contents = await readFile(file, 'utf8');
+
+			if (contents.includes(packageName)) {
+				throw new Error(
+					`Function build artifact "${context}" references "${packageName}" in "${file}". Remove the dependency from the function bundle or configure it explicitly.`
+				);
+			}
+		}
+	}
+
+	private static async getFiles(dir: string): Promise<string[]> {
+		const entries = await readdir(dir, { withFileTypes: true });
+		const files = await Promise.all(
+			entries.map((entry) => {
+				const path = join(dir, entry.name);
+				return entry.isDirectory() ? ServicePackager.getFiles(path) : [path];
+			})
+		);
+
+		return files.flat();
+	}
+
 	/**
 	 * Build the API proxy using Rspack
 	 * @private
@@ -338,6 +372,8 @@ export class ServicePackager {
 							: []),
 					],
 				});
+
+				await ServicePackager.assertArtifactDoesNotReferencePackage(outdir, 'routing-controllers', dir);
 			})
 		);
 	}
@@ -356,7 +392,7 @@ export class ServicePackager {
 		if (buildOptions?.copyFiles) {
 			this.logger('Copying files...');
 
-			for await (const opts of buildOptions.copyFiles) {
+			for (const opts of buildOptions.copyFiles) {
 				await this.copyNonTranspiledFiles(opts, ServicePackager.config);
 			}
 		}
@@ -457,7 +493,7 @@ export class ServicePackager {
 	 * @param {LogColour} colour
 	 * @param context
 	 */
-	private logger = (msg: string, colour: LogColour = LogColour.Cyan, context?: string) => {
+	private readonly logger = (msg: string, colour: LogColour = LogColour.Cyan, context?: string) => {
 		const prefix = context ? `[${context}] ` : '';
 		console.log(`\x1b[${colour}m%s\x1b[0m`, `\n${prefix}${msg}`);
 	};


### PR DESCRIPTION
## Description
- When `routing-controllers' is imported in the path of a function, the build will now fail in order to signify this will break on Lambda

<img width="1135" height="288" alt="Screenshot 2026-04-22 at 10 40 34" src="https://github.com/user-attachments/assets/189a683d-b967-4ed0-be78-5a3417c4b923" />


Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
