### PR TITLE
feat(cb2-21006): update test stations feature flag to import test stations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20253,7 +20253,7 @@
     },
     "packages/feature-flags": {
       "name": "@dvsa/cvs-feature-flags",
-      "version": "0.26.0",
+      "version": "0.27.0",
       "license": "ISC",
       "dependencies": {
         "@aws-lambda-powertools/parameters": "^2.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20253,7 +20253,7 @@
     },
     "packages/feature-flags": {
       "name": "@dvsa/cvs-feature-flags",
-      "version": "0.27.0",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@aws-lambda-powertools/parameters": "^2.16.0",

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-feature-flags",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Common package to be used in CVS to manage feature flags",
   "author": "DVSA",
   "license": "ISC",

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-feature-flags",
-  "version": "0.27.0",
+  "version": "1.0.0",
   "description": "Common package to be used in CVS to manage feature flags",
   "author": "DVSA",
   "license": "ISC",

--- a/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
+++ b/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
@@ -44,7 +44,7 @@ describe('app config configuration', () => {
 		expect(flags.skipAutomatedProcesses.syncTestResultInfo).toBe(false);
 		expect(flags.skipAutomatedProcesses.updateStoreTechRecords).toBe(false);
 		expect(flags.skipAutomatedProcesses.updateStoreTestResults).toBe(false);
-		expect(flags.skipAutomatedProcesses.updateTestStation).toBe(false);
+		expect(flags.skipAutomatedProcesses.importTestStation).toBe(false);
 		expect(flags.skipAutomatedProcesses.updateTestVrm).toBe(false);
 	});
 

--- a/packages/feature-flags/src/profiles/vtx.ts
+++ b/packages/feature-flags/src/profiles/vtx.ts
@@ -46,7 +46,7 @@ const defaultFeatureFlags = {
 		syncTestResultInfo: false,
 		updateStoreTechRecords: false,
 		updateStoreTestResults: false,
-		updateTestStation: false,
+		importTestStation: false,
 		updateTestVrm: false,
 	},
 


### PR DESCRIPTION
## Description

For clarity, refactored updateTestStation attribute to importTestStation, so it is consistent with the new name of the function that retrieves (imports) the data from Dynamics.

Related issue: [CB2-21006](https://dvsa.atlassian.net/browse/CB2-21006)

## Before submitting (or marking as "ready for review")

- [X] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [X] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[CB2-21006]: https://dvsa.atlassian.net/browse/CB2-21006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ