### PR TITLE
feat(cb2-21660): add specialist defect attribute for skipping adas export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20543,7 +20543,7 @@
     },
     "packages/feature-flags": {
       "name": "@dvsa/cvs-feature-flags",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "@aws-lambda-powertools/parameters": "^2.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20543,7 +20543,7 @@
     },
     "packages/feature-flags": {
       "name": "@dvsa/cvs-feature-flags",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
         "@aws-lambda-powertools/parameters": "^2.16.0",

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-feature-flags",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Common package to be used in CVS to manage feature flags",
   "author": "DVSA",
   "license": "ISC",

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-feature-flags",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Common package to be used in CVS to manage feature flags",
   "author": "DVSA",
   "license": "ISC",

--- a/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
+++ b/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
@@ -18,6 +18,7 @@ describe('app config configuration', () => {
 		expect(flags.specialistDefects.adasImNumbers).toEqual([29]);
 		expect(flags.specialistDefects.includeOnCertificates).toBe(false);
 		expect(flags.specialistDefects.includeOnEnquiry).toBe(false);
+		expect(flags.specialistDefects.skipAdasExport).toBe(false);
 		expect(flags.skipAutomatedProcesses.enabled).toBe(false);
 		expect(flags.skipAutomatedProcesses.atfReportGen).toBe(false);
 		expect(flags.skipAutomatedProcesses.centralDocsNotify).toBe(false);
@@ -50,6 +51,7 @@ describe('app config configuration', () => {
 				adasImNumbers: [29, 99],
 				includeOnCertificates: true,
 				includeOnEnquiry: true,
+				skipAdasExport: true,
 			},
 			skipAutomatedProcesses: {
 				enabled: true,
@@ -68,6 +70,7 @@ describe('app config configuration', () => {
 		expect(flags.specialistDefects.adasImNumbers).toEqual([29, 99]);
 		expect(flags.specialistDefects.includeOnCertificates).toBe(true);
 		expect(flags.specialistDefects.includeOnEnquiry).toBe(true);
+		expect(flags.specialistDefects.skipAdasExport).toBe(true);
 		expect(flags.skipAutomatedProcesses.enabled).toBe(true);
 		expect(flags.skipAutomatedProcesses.certGovNotify).toBe(true);
 		expect(flags.skipAutomatedProcesses.exportAnts).toBe(true);

--- a/packages/feature-flags/src/profiles/vtx.ts
+++ b/packages/feature-flags/src/profiles/vtx.ts
@@ -11,6 +11,7 @@ const defaultFeatureFlags = {
 		adasImNumbers: [29],
 		includeOnCertificates: false,
 		includeOnEnquiry: false,
+		skipAdasExport: false,
 	},
 	skipAutomatedProcesses: {
 		enabled: false,


### PR DESCRIPTION
## Description

This adds a new attribute, skipAdasExport to the specialistDefects FF, which can subsequently be used to halt the Adas report generation and sharepoint upload flow. 

This will be used as part of the first step of the flow: **CB2-21659**, which in turn will also prevent the sharepoint upload.

Related issue: [CB2-21660](https://dvsa.atlassian.net/browse/CB2-21660)

## Before submitting (or marking as "ready for review")

- [X] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [X] Have you have added tests that prove the fix or feature is effective and working
- [X] Did you make sure to update any documentation relating to this change?


[CB2-21660]: https://dvsa.atlassian.net/browse/CB2-21660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ