### PR TITLE
feat(cb2-20364): added more test type consts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18884,7 +18884,7 @@
     },
     "packages/cvs-common": {
       "name": "@dvsa/cvs-microservice-common",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "license": "ISC",
       "dependencies": {
         "class-transformer": "^0.5.1",

--- a/packages/cvs-common/package.json
+++ b/packages/cvs-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-microservice-common",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Common package to be used in CVS microservices",
   "author": "DVSA",
   "license": "ISC",

--- a/packages/cvs-common/src/classes/testTypes/Constants.ts
+++ b/packages/cvs-common/src/classes/testTypes/Constants.ts
@@ -353,3 +353,15 @@ export const SPECIALIST_TEST_TYPE: ITestTypeList = {
 		'185',
 	],
 };
+
+export const FIRST_TEST: ITestTypeList = {
+	IDS: ['41', '95', '65', '66', '67', '103', '104', '82', '83', '119', '120'],
+};
+
+export const NOTIFIABLE_ALTERATION_TEST: ITestTypeList = {
+	IDS: ['38', '47', '48'],
+};
+
+export const COIF_TEST: ITestTypeList = {
+	IDS: ['142', '143', '175', '176'],
+};

--- a/packages/cvs-common/src/classes/testTypes/__tests__/testTypes.spec.ts
+++ b/packages/cvs-common/src/classes/testTypes/__tests__/testTypes.spec.ts
@@ -3,11 +3,14 @@ import {
 	ANNUAL_WITH_CERTIFICATE,
 	BASIC_IVA_TEST,
 	CENTRAL_DOCS_TEST,
+	COIF_TEST,
+	FIRST_TEST,
 	HGV_TRL_RWT_TEST,
 	IVA_TEST,
 	LEC_TEST,
 	LOAD_STATUS_TEST,
 	MSVA_TEST,
+	NOTIFIABLE_ALTERATION_TEST,
 	PROHIBITION_CLEARANCE_TEST,
 	SPECIALIST_TEST_TYPE,
 	TIR_TEST,
@@ -32,6 +35,9 @@ describe('validateTestTypeIdInList', () => {
 		const resultVoluntaryIvaTest = TestTypeHelper.validateTestTypeIdInList(VOLUNTARY_IVA_TEST, '191');
 		const resultSpecialistTest = TestTypeHelper.validateTestTypeIdInList(SPECIALIST_TEST_TYPE, '133');
 		const resultLoadStatusTest = TestTypeHelper.validateTestTypeIdInList(LOAD_STATUS_TEST, '94');
+		const resultFirstTest = TestTypeHelper.validateTestTypeIdInList(FIRST_TEST, '41');
+		const resultNotifiableAlteration = TestTypeHelper.validateTestTypeIdInList(NOTIFIABLE_ALTERATION_TEST, '38');
+		const resultCoifTest = TestTypeHelper.validateTestTypeIdInList(COIF_TEST, '142');
 
 		expect(resultLEC).toBe(true);
 		expect(resultADR).toBe(true);
@@ -47,6 +53,9 @@ describe('validateTestTypeIdInList', () => {
 		expect(resultVoluntaryIvaTest).toBe(true);
 		expect(resultSpecialistTest).toBe(true);
 		expect(resultLoadStatusTest).toBe(true);
+		expect(resultFirstTest).toBe(true);
+		expect(resultNotifiableAlteration).toBe(true);
+		expect(resultCoifTest).toBe(true);
 	});
 
 	it('should return false if test type id does not exist in list provided', () => {
@@ -64,6 +73,9 @@ describe('validateTestTypeIdInList', () => {
 		const resultVoluntaryIvaTest = TestTypeHelper.validateTestTypeIdInList(VOLUNTARY_IVA_TEST, '0');
 		const resultSpecialistTest = TestTypeHelper.validateTestTypeIdInList(SPECIALIST_TEST_TYPE, '0');
 		const resultLoadStatusTest = TestTypeHelper.validateTestTypeIdInList(LOAD_STATUS_TEST, '0');
+		const resultFirstTest = TestTypeHelper.validateTestTypeIdInList(FIRST_TEST, '0');
+		const resultNotifiableAlteration = TestTypeHelper.validateTestTypeIdInList(NOTIFIABLE_ALTERATION_TEST, '0');
+		const resultCoifTest = TestTypeHelper.validateTestTypeIdInList(COIF_TEST, '0');
 
 		expect(resultLEC).toBe(false);
 		expect(resultADR).toBe(false);
@@ -79,6 +91,9 @@ describe('validateTestTypeIdInList', () => {
 		expect(resultVoluntaryIvaTest).toBe(false);
 		expect(resultSpecialistTest).toBe(false);
 		expect(resultLoadStatusTest).toBe(false);
+		expect(resultFirstTest).toBe(false);
+		expect(resultNotifiableAlteration).toBe(false);
+		expect(resultCoifTest).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## Description

Moving v3 to the new domain identified an opportunity to consolidate some of the defined const/lists of test type ids for specific types of tests.

Related issue: [CB2-20364](https://dvsa.atlassian.net/browse/CB2-20364)

## Before submitting (or marking as "ready for review")

- [X] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [X] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[CB2-20364]: https://dvsa.atlassian.net/browse/CB2-20364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ